### PR TITLE
Inline command list and improve power estimation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+# v0.5.4 - July 29, 2025
+
+## Changed
+- GET /api/ups/{ups_name} returns instant commands without extra query parameters.
+- UPS power is estimated from load and nominal values when direct metrics are missing.
+
+## Added
+- UI marks approximated power readings.
+
 # v0.5.3 - July 28, 2025
 
 ## Added

--- a/docs/api_specs/openapi3_spec.json
+++ b/docs/api_specs/openapi3_spec.json
@@ -260,66 +260,6 @@
       }
     },
     "/api/ups/{ups_name}/instcmd": {
-      "get": {
-        "parameters": [
-          {
-            "name": "ups_name",
-            "in": "path",
-            "description": "UPS name",
-            "required": true,
-            "allowEmptyValue": false,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "tags": [
-          "ups"
-        ],
-        "operationId": "api_ups_list_instcmd",
-        "responses": {
-          "200": {
-            "description": "Instant command list.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InstCmdList"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Upsd user and password configs are not set.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Ups does not exists.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "UPS daemon unreachable.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      },
       "description": "Instantiate UPS INSTCMD command.",
       "post": {
         "requestBody": {
@@ -701,26 +641,22 @@
             }
           },
           "commands": {
-            "oneOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/InstCmd"
-                }
-              }
-            ]
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InstCmd"
+            }
           },
           "attached": {
             "type": "array",
             "items": {
               "type": "string"
             }
+          },
+          "power_w": {
+            "type": "number"
+          },
+          "power_is_approx": {
+            "type": "boolean"
           }
         }
       },
@@ -815,8 +751,7 @@
       "InstCmd": {
         "type": "object",
         "required": [
-          "id",
-          "desc"
+          "id"
         ],
         "properties": {
           "id": {

--- a/docs/api_specs/openapi3_spec.yaml
+++ b/docs/api_specs/openapi3_spec.yaml
@@ -169,43 +169,6 @@ paths:
                 $ref: "#/components/schemas/ProblemDetails"
 
   /api/ups/{ups_name}/instcmd:
-    get:
-      parameters:
-        - name: ups_name
-          in: path
-          description: "UPS name"
-          required: true
-          allowEmptyValue: false
-          schema:
-            type: string
-      tags:
-        - ups
-      operationId: "api_ups_list_instcmd"
-      responses:
-        "200":
-          description: "Instant command list."
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/InstCmdList"
-        "401":
-          description: "Upsd user and password configs are not set."
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ProblemDetails"
-        "404":
-          description: "Ups does not exists."
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ProblemDetails"
-        "502":
-          description: "UPS daemon unreachable."
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ProblemDetails"
     description: "Instantiate UPS INSTCMD command."
     post:
       requestBody:
@@ -448,17 +411,17 @@ components:
               - type: "number"
               - type: "string"
         commands:
-          oneOf:
-            - type: "array"
-              items:
-                type: "string"
-            - type: "array"
-              items:
-                $ref: "#/components/schemas/InstCmd"
+          type: array
+          items:
+            $ref: "#/components/schemas/InstCmd"
         attached:
           type: "array"
           items:
             type: "string"
+        power_w:
+          type: number
+        power_is_approx:
+          type: boolean
 
     UpsList:
       type: array
@@ -523,7 +486,6 @@ components:
       type: object
       required:
         - id
-        - desc
       properties:
         id:
           type: string

--- a/nut_webgui/Cargo.lock
+++ b/nut_webgui/Cargo.lock
@@ -799,6 +799,7 @@ dependencies = [
  "futures",
  "nut_webgui_client",
  "nut_webgui_upsmc",
+ "once_cell",
  "serde",
  "serde_json",
  "tokio",

--- a/nut_webgui/Cargo.toml
+++ b/nut_webgui/Cargo.toml
@@ -58,3 +58,4 @@ tower-http = { version = "0.6", features = [
 tracing = "0.1"
 tracing-subscriber = "0.3"
 serde_json = { version = "1" }
+once_cell = "1"

--- a/nut_webgui/src/http.rs
+++ b/nut_webgui/src/http.rs
@@ -68,16 +68,11 @@ impl HttpServer {
       .fallback(|| async { StatusCode::NOT_FOUND })
       .layer(CorsLayer::permissive());
 
-    let instcmd_route = if config.allow_instcmds_list {
-      get(json::get_instcmds).post(json::post_command)
-    } else {
-      post(json::post_command)
-    };
-    let data_api = Router::new()
-      .route("/ups", get(json::get_ups_list))
-      .route("/ups/{ups_name}", get(json::get_ups_by_name))
-      .route("/ups/{ups_name}", patch(json::patch_var))
-      .route("/ups/{ups_name}/instcmd", instcmd_route)
+      let data_api = Router::new()
+        .route("/ups", get(json::get_ups_list))
+        .route("/ups/{ups_name}", get(json::get_ups_by_name))
+        .route("/ups/{ups_name}", patch(json::patch_var))
+        .route("/ups/{ups_name}/instcmd", post(json::post_command))
       .route(
         "/ups/{ups_name}/fsd",
         post(json::post_fsd).layer(ValidateRequestHeaderLayer::custom(

--- a/nut_webgui/src/http/hypermedia/templates/+page.html
+++ b/nut_webgui/src/http/hypermedia/templates/+page.html
@@ -87,12 +87,12 @@
                       </div>
                       <div class="stat-title">Ups Power</div>
                       <div class="stat-value text-lg">
-                        {%- match row.power -%}
-                          {%- when Some(power) -%}
-                            <div class="text-center w-full {{power.class.as_text()}}">{{power}}</div>
-                          {%- when None -%}
-                            <p class="font-bold opacity-50 text-center">N/A</p>
-                        {%- endmatch -%}
+                          {%- match row.power -%}
+                            {%- when Some(power) -%}
+                              <div class="text-center w-full {{power.class.as_text()}}">{%- if power.approx -%}≈ {% endif -%}{{power}}</div>
+                            {%- when None -%}
+                              <p class="font-bold opacity-50 text-center">N/A</p>
+                          {%- endmatch -%}
                       </div>
                     </div>
                     <div class="col-span-full md:col-span-2 stat xl:col-span-1 xs:col-span-3">

--- a/nut_webgui/src/http/hypermedia/templates/ups/+page.html
+++ b/nut_webgui/src/http/hypermedia/templates/ups/+page.html
@@ -103,10 +103,12 @@
               {%- call tab_button(device.name, tab_name = "clients", title = "Clients", icon = "monitor", is_active = false) -%}
             {%- endif -%}
 
-            {%- if let UpsPageTabTemplate::Commands { .. } = tab_template  -%}
-              {%- call tab_button(device.name, tab_name = "commands", title = "Commands", icon = "play", is_active = true) -%}
-            {%- else -%}
-              {%- call tab_button(device.name, tab_name = "commands", title = "Commands", icon = "play", is_active = false) -%}
+            {%- if !device.commands.is_empty() -%}
+              {%- if let UpsPageTabTemplate::Commands { .. } = tab_template  -%}
+                {%- call tab_button(device.name, tab_name = "commands", title = "Commands", icon = "play", is_active = true) -%}
+              {%- else -%}
+                {%- call tab_button(device.name, tab_name = "commands", title = "Commands", icon = "play", is_active = false) -%}
+              {%- endif -%}
             {%- endif -%}
 
             {%- if let UpsPageTabTemplate::Rw { .. } = tab_template  -%}

--- a/nut_webgui/src/http/hypermedia/templates/ups/tab_commands.html
+++ b/nut_webgui/src/http/hypermedia/templates/ups/tab_commands.html
@@ -1,5 +1,6 @@
 {%- import "icons.html" as icons -%}
 {%- let base_path = askama::get_value::<String>("HTTP_SERVER__BASE_PATH")? -%}
+{%- if !device.commands.is_empty() -%}
 
 <div class="content-card flex flex-col gap-4">
   <h2 class="opacity-60 text-lg tracking-wide">Commands</h2>
@@ -75,3 +76,4 @@
     {%- endfor -%}
   </nut-search-list>
 </div>
+{%- endif -%}

--- a/nut_webgui_upsmc/Cargo.toml
+++ b/nut_webgui_upsmc/Cargo.toml
@@ -29,7 +29,7 @@ tokio-test = { version = "0.4" }
 serde_json = { version = "1" }
 
 [dependencies]
-serde = { version = "1", optional = true }
+serde = { version = "1", optional = true, features = ["derive"] }
 tokio = { version = "1", features = [
         "net",
         "io-util",

--- a/nut_webgui_upsmc/src/inst_cmd.rs
+++ b/nut_webgui_upsmc/src/inst_cmd.rs
@@ -2,7 +2,7 @@ use crate::CmdName;
 #[cfg(feature = "serde")]
 use serde::Serialize;
 #[cfg_attr(feature = "serde", derive(Serialize))]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct InstCmd {
   pub id: CmdName,
   pub desc: String,


### PR DESCRIPTION
## Summary
- inline UPS instant commands in device detail responses with short caching
- estimate UPS power from load and nominal values and flag approximations
- simplify instcmd API and update documentation and UI

## Testing
- `make test` *(failed: test_device_integration)*

------
https://chatgpt.com/codex/tasks/task_e_689d2c934094832dbd2bb7b6825458f5