### PR TITLE
Always display Commands tab with default FSD action

### DIFF
--- a/nut_webgui/src/http/hypermedia/templates/ups/+page.html
+++ b/nut_webgui/src/http/hypermedia/templates/ups/+page.html
@@ -103,12 +103,10 @@
               {%- call tab_button(device.name, tab_name = "clients", title = "Clients", icon = "monitor", is_active = false) -%}
             {%- endif -%}
 
-            {%- if !device.commands.is_empty() -%}
-              {%- if let UpsPageTabTemplate::Commands { .. } = tab_template  -%}
-                {%- call tab_button(device.name, tab_name = "commands", title = "Commands", icon = "play", is_active = true) -%}
-              {%- else -%}
-                {%- call tab_button(device.name, tab_name = "commands", title = "Commands", icon = "play", is_active = false) -%}
-              {%- endif -%}
+            {%- if let UpsPageTabTemplate::Commands { .. } = tab_template  -%}
+              {%- call tab_button(device.name, tab_name = "commands", title = "Commands", icon = "play", is_active = true) -%}
+            {%- else -%}
+              {%- call tab_button(device.name, tab_name = "commands", title = "Commands", icon = "play", is_active = false) -%}
             {%- endif -%}
 
             {%- if let UpsPageTabTemplate::Rw { .. } = tab_template  -%}

--- a/nut_webgui/src/http/hypermedia/templates/ups/tab_commands.html
+++ b/nut_webgui/src/http/hypermedia/templates/ups/tab_commands.html
@@ -1,7 +1,5 @@
 {%- import "icons.html" as icons -%}
 {%- let base_path = askama::get_value::<String>("HTTP_SERVER__BASE_PATH")? -%}
-{%- if commands.len() > 0 -%}
-
 <div class="content-card flex flex-col gap-4">
   <h2 class="opacity-60 text-lg tracking-wide">Commands</h2>
   <label class="input input-ghost input-sm opacity-60 tracking-wide">
@@ -74,7 +72,3 @@
     {%- endfor -%}
   </nut-search-list>
 </div>
-{%- else -%}
-<p>No instant commands exposed by NUT for this UPS</p>
-<p class="opacity-60 text-sm">Check instcmd permissions in upsd.users</p>
-{%- endif -%}


### PR DESCRIPTION
## Summary
- Render Commands tab unconditionally
- Keep Forced Shutdown control visible even when no device commands are loaded

## Testing
- `make test` *(fails: 715 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_689d5994586c832d87cc19d8fd958735