### PR TITLE
Remove unused instcmd listing and restore docs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,7 @@
-# v0.5.4 - July 29, 2025
+# v0.5.3 - July 28, 2025
 
-## Changed
-- UPS power is estimated from load and nominal values when direct metrics are missing.
-
-## Added
-- UI marks approximated power readings.
+## Fixed
+- Compressed assets does not work on some browsers.
 
 # v0.5.2 - July 28, 2025
 

--- a/README.md
+++ b/README.md
@@ -125,8 +125,6 @@ poll_interval = 2
 
 For more detailed config template see [./containers/config.toml](./containers/config.toml).
 
-### API examples
-
 > Log level options: `info`, `warn`, `error`, `debug`, `trace`
 
 ## JSON data API

--- a/nut_webgui/Cargo.lock
+++ b/nut_webgui/Cargo.lock
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.20"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -73,22 +73,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -219,7 +219,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -239,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.2"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "block-buffer"
@@ -254,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "9991eea70ea4f293524138648e41ee89b0b2b12ddef3b255effa43c8056e0e0d"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -287,9 +287,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.33"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee0f8803222ba5a7e2777dd72ca451868909b1ac410621b676adf07280e9b5f"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "shlex",
 ]
@@ -313,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.45"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -323,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.44"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -335,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.45"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -539,9 +539,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heck"
@@ -711,9 +711,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "log"
@@ -766,7 +766,7 @@ checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -873,9 +873,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -903,9 +903,9 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -935,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",
@@ -1004,18 +1004,18 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.6"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "smallvec"
@@ -1030,7 +1030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1041,9 +1041,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1067,9 +1067,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.47.1"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1081,7 +1081,7 @@ dependencies = [
  "slab",
  "socket2",
  "tokio-macros",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1097,9 +1097,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.16"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1443,16 +1443,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1461,31 +1452,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -1495,22 +1469,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1519,22 +1481,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1543,22 +1493,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1567,22 +1505,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"

--- a/nut_webgui/src/config/error.rs
+++ b/nut_webgui/src/config/error.rs
@@ -1,5 +1,5 @@
 use crate::uri_path::InvalidPathError;
-use core::{net::AddrParseError, num::ParseIntError, str::ParseBoolError};
+use core::{net::AddrParseError, num::ParseIntError};
 use std::ffi::OsString;
 
 #[derive(Debug)]
@@ -43,7 +43,6 @@ pub enum EnvConfigError {
   IOError { inner: std::io::Error },
   NonUnicodeVar { variable: OsString },
   InvalidNumericFormat { inner: ParseIntError },
-  InvalidBoolFormat { inner: ParseBoolError },
   InvalidLogLevelFormat,
   InvalidAddrFormat { inner: core::net::AddrParseError },
   InvalidUriPath,
@@ -64,8 +63,9 @@ impl std::fmt::Display for EnvConfigError {
       EnvConfigError::InvalidNumericFormat { .. } => {
         f.write_fmt(format_args!("invalid numeric format"))
       }
-      EnvConfigError::InvalidBoolFormat { .. } => f.write_fmt(format_args!("invalid bool format")),
-      EnvConfigError::InvalidLogLevelFormat => f.write_fmt(format_args!("invalid log level")),
+      EnvConfigError::InvalidLogLevelFormat => {
+        f.write_fmt(format_args!("invalid log level"))
+      }
       EnvConfigError::InvalidAddrFormat { inner } => {
         f.write_fmt(format_args!("invalid ip address format, {}", inner))
       }
@@ -125,8 +125,3 @@ impl From<std::io::Error> for EnvConfigError {
   }
 }
 
-impl From<ParseBoolError> for EnvConfigError {
-  fn from(value: ParseBoolError) -> Self {
-    Self::InvalidBoolFormat { inner: value }
-  }
-}

--- a/nut_webgui_upsmc/Cargo.toml
+++ b/nut_webgui_upsmc/Cargo.toml
@@ -29,7 +29,7 @@ tokio-test = { version = "0.4" }
 serde_json = { version = "1" }
 
 [dependencies]
-serde = { version = "1", optional = true, features = ["derive"] }
+serde = { version = "1", optional = true }
 tokio = { version = "1", features = [
         "net",
         "io-util",

--- a/nut_webgui_upsmc/src/clients/client_auth.rs
+++ b/nut_webgui_upsmc/src/clients/client_auth.rs
@@ -199,13 +199,6 @@ where
     Ok(())
   }
 
-  pub async fn list_instcmds<N>(&mut self, ups: N) -> Result<Vec<crate::InstCmd>, Error>
-  where
-    N: Borrow<UpsName>,
-  {
-    self.inner.list_instcmds(ups).await
-  }
-
   #[inline]
   pub fn is_open(&mut self) -> impl Future<Output = bool> {
     self.inner.is_open()

--- a/nut_webgui_upsmc/src/clients/client_base.rs
+++ b/nut_webgui_upsmc/src/clients/client_base.rs
@@ -157,23 +157,7 @@ where
     }
   }
 
-  pub async fn list_instcmds<N>(&mut self, ups: N) -> Result<Vec<crate::InstCmd>, Error>
-  where
-    N: Borrow<UpsName>,
-  {
-    let ups = ups.borrow();
-    let cmds = AsyncNutClient::list_cmd(&mut *self, ups).await?.cmds;
-    let mut output = Vec::with_capacity(cmds.len());
-    for cmd in cmds {
-      let desc = AsyncNutClient::get_cmd_desc(&mut *self, ups, &cmd)
-        .await
-        .map(|d| d.desc.into())
-        .unwrap_or_default();
-      output.push(crate::InstCmd { id: cmd, desc });
-    }
-    Ok(output)
   }
-}
 
 impl<S> AsyncNutClient for &mut NutClient<S>
 where

--- a/nut_webgui_upsmc/src/inst_cmd.rs
+++ b/nut_webgui_upsmc/src/inst_cmd.rs
@@ -1,9 +1,0 @@
-use crate::CmdName;
-#[cfg(feature = "serde")]
-use serde::Serialize;
-#[cfg_attr(feature = "serde", derive(Serialize))]
-#[derive(Debug, Clone)]
-pub struct InstCmd {
-  pub id: CmdName,
-  pub desc: String,
-}

--- a/nut_webgui_upsmc/src/lib.rs
+++ b/nut_webgui_upsmc/src/lib.rs
@@ -2,7 +2,6 @@ pub(crate) mod internal;
 
 mod cmd_name;
 mod commands;
-mod inst_cmd;
 mod ups_name;
 mod value;
 mod var_name;
@@ -16,7 +15,6 @@ pub mod ups_status;
 pub mod variables;
 
 pub use cmd_name::*;
-pub use inst_cmd::*;
 pub use ups_name::*;
 pub use value::*;
 pub use var_name::*;

--- a/nut_webgui_upsmc/tests/test_client.rs
+++ b/nut_webgui_upsmc/tests/test_client.rs
@@ -473,30 +473,6 @@ async fn instcmd() {
 }
 
 #[tokio::test]
-async fn list_instcmds() {
-  const LIST_CMD: &[u8] =
-    b"BEGIN LIST CMD ux\nCMD ux beeper.toggle\nCMD ux driver.reload\nEND LIST CMD ux\n";
-  const DESC1: &[u8] = b"CMDDESC ux beeper.toggle \"Toggle\"\n";
-  const DESC2: &[u8] = b"CMDDESC ux driver.reload \"Reload\"\n";
-  let ups = UpsName::new_unchecked("ux");
-  let stream = tokio_test::io::Builder::new()
-    .write(format!("LIST CMD {ups}\n", ups = &ups).as_bytes())
-    .read(LIST_CMD)
-    .write(format!("GET CMDDESC {ups} beeper.toggle\n", ups = &ups).as_bytes())
-    .read(DESC1)
-    .write(format!("GET CMDDESC {ups} driver.reload\n", ups = &ups).as_bytes())
-    .read(DESC2)
-    .build();
-  let mut client = nut_webgui_upsmc::clients::NutClient::from(stream);
-  let cmds = client.list_instcmds(&ups).await.unwrap();
-  assert_eq!(cmds.len(), 2);
-  assert_eq!(cmds[0].id, CmdName::new_unchecked("beeper.toggle"));
-  assert_eq!(cmds[0].desc, "Toggle");
-  assert_eq!(cmds[1].id, CmdName::new_unchecked("driver.reload"));
-  assert_eq!(cmds[1].desc, "Reload");
-}
-
-#[tokio::test]
 async fn fsd() {
   let ups = nut_webgui_upsmc::UpsName::new_unchecked("home:bx1600mi@localhost:4242");
   let stream = tokio_test::io::Builder::new()


### PR DESCRIPTION
## Summary
- drop InstCmd struct and command listing helpers from client library
- revert changelog, readme and lockfile to upstream versions
- prune unused boolean parse error from config layer

## Testing
- `cargo test` *(fails: test_device_integration, 715 failures)*
- `cargo test` (nut_webgui) *(fails: missing Node `esbuild` for nut_webgui_client build)*

------
https://chatgpt.com/codex/tasks/task_e_68a267911a84832db8883d1d6953a787